### PR TITLE
Enabled PythiaGenerator to work without a LHE file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,8 @@ channels:
 
 dependencies:
   - pip
-  - python>=3.7
+  - python>=3.8
   - lxml
   - numpy
-  - pandas
   - pythia8
   - rich=12.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "requests",
     "lxml",
     "numpy",
-    "pandas",
     "rich",
 ]
 

--- a/showerpipe/generator.py
+++ b/showerpipe/generator.py
@@ -289,9 +289,8 @@ class PythiaGenerator(base.GeneratorAdapter):
         config: ty.Dict[str, ty.Dict[str, str]] = {
             "Print": {"quiet": "on" if quiet else "off"},
             "Random": {"setSeed": "on", "seed": str(rng_seed)},
-            "Beams": {"frameType": "4"},
         }
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             for line in f:
                 key, val = line.partition("=")[::2]
                 sup_key, sub_key = map(lambda s: s.strip(), key.split(":"))

--- a/showerpipe/generator.py
+++ b/showerpipe/generator.py
@@ -299,6 +299,18 @@ class PythiaGenerator(base.GeneratorAdapter):
                 config.setdefault(sup_key, dict())
                 config[sup_key][sub_key] = val.strip()
         if lhe_file is not None:
+            frame_type = config.get("Beams", {}).get("frameType", None)
+            if frame_type is None:
+                warnings.warn(
+                    "Beams:frameType not set. Inserting default of 4 for LHE "
+                    "compatibility.",
+                    UserWarning,
+                )
+                frame_type = "4"
+                config.setdefault("Beams", {})
+                config["Beams"]["frameType"] = frame_type
+            if int(frame_type) != 4:
+                raise ValueError("Must set 'Beams:frameType = 4' for LHE data")
             self._num_events = lhe.count_events(lhe_file)
             with lhe.source_adapter(lhe_file) as f:
                 self.temp_lhe_file = tf.NamedTemporaryFile()


### PR DESCRIPTION
Previously, data generation was only implemented for runs which provided LHE files as input. This functionality has now been enabled. Additionally, Beams:frameType now checks for consistency, and will emit a warning if omitted for a LHE file run, and throw an exception if the wrong value is passed.